### PR TITLE
Favicon

### DIFF
--- a/web/templates/layout/application.html.eex
+++ b/web/templates/layout/application.html.eex
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
+    <link href="/images/stockholm_elixir.png" rel="shortcut icon" />
 
     <title>Stockholm Elixir</title>
     <link href="//fonts.googleapis.com/css?family=Cabin:400,700" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Closes #9.

PNG for simplicity, though this excludes IE10 and earlier:
https://en.wikipedia.org/wiki/Favicon#File_format_support